### PR TITLE
Post testing changes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 const serializer = require('./serializer')
 
 module.exports = (data, model, options = { baseUrl: '/' }) => {
-  return serializer(options).serialize(structuredClone(data), model)
+  return serializer(options).serialize(JSON.parse(JSON.stringify(data)), model)
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,26 +1,6 @@
 'use strict'
 
-/**
- * Performs a deep merge on 2 objects.
- * Does not work on Arrays.
- * Is recursive... be careful!
- *
- * @param {object} obj1
- * @param {object} obj2
- * @returns {object} the merged object
- */
-function deepMerge(obj1, obj2) {
-  for (let key in obj2) {
-    if (obj2.hasOwnProperty(key)) {
-      if (obj2[key] instanceof Object && obj1[key] instanceof Object) {
-        obj1[key] = deepMerge(obj1[key], obj2[key])
-      } else {
-        obj1[key] = obj2[key]
-      }
-    }
-  }
-  return obj1
-}
+const merge = require('lodash.merge')
 
 module.exports = (options = { baseUrl: '/' }) => {
   function primaryKeyForModel(model) {
@@ -46,7 +26,7 @@ module.exports = (options = { baseUrl: '/' }) => {
   function buildRelationships(data, model) {
     const relationshipLinks = relationshipLinksFromData(data, model)
     const relationshipData = relationshipDataFromData(data, model)
-    return deepMerge(relationshipLinks, relationshipData)
+    return merge(relationshipLinks, relationshipData)
   }
 
   function buildAttributes(data, model, opts = {}) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@mediasuite/loopback-jsonapi-model-serializer",
       "version": "2.0.0",
       "license": "MIT",
+      "dependencies": {
+        "lodash.merge": "^4.6.2"
+      },
       "devDependencies": {
         "ava": "^6.4.1",
         "chai": "^3.5.0",
@@ -3897,6 +3900,12 @@
         "lodash.isarguments": "^3.0.0",
         "lodash.isarray": "^3.0.0"
       }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "license": "MIT"
     },
     "node_modules/loopback": {
       "version": "3.28.0",

--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
     "mocha": "^3.5.3",
     "prettier": "^3.6.2",
     "xyz": "^0.5.0"
+  },
+  "dependencies": {
+    "lodash.merge": "^4.6.2"
   }
 }

--- a/test/performance.spec.js
+++ b/test/performance.spec.js
@@ -1,6 +1,6 @@
 import test from 'ava'
 import loopback from 'loopback'
-import serializer from '../lib/serializer.js'
+import serializer from '../lib/index.js'
 
 test.before((t) => {
   const app = (t.context.app = loopback())
@@ -45,7 +45,7 @@ test('performance test serializing 1000 posts with nested relations', (t) => {
   const { Post } = t.context.app.models
   const data = t.context.posts
 
-  const posts = serializer({ baseUrl: 'http://example' }).serialize(data, Post)
+  const posts = serializer(data, Post, { baseUrl: 'http://example' })
 
   t.truthy(posts)
   t.true(Array.isArray(posts.data))


### PR DESCRIPTION
These change fixes an issue that was picked up in testing downstream. They did not break the tests within this module, because the test case only covered the serializer but not the full interface.

- the `JSON.parse(JSON.stringify())` in `lib/index.js` is required as the data is a Model class, and needs to have `.toJSON` or `.toObject` called on it. `structuredClone()` was doing the right thing, but not the correct behaviour!
- added back in just `lodash.merge`, as there are potential situations that the native JS merge may break (when merging arrays e.g.)
- Updated the performance test to behave like this module is used in downstream codebases.